### PR TITLE
feat: show status icon in the file header

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
       {
         "id": "langserver.status",
         "actionItem": {
-          "description": "${get(context, `langserver.statusDescription`)}",
-          "iconURL": "${get(context, `langserver.statusIconURL`)}"
+          "description": "Code intelligence active for ${resource.language}",
+          "iconURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjQgMjQiPgogICAgICAgICAgICAgICAgICAgPHN2ZyBjbGFzcz0ibWRpLWljb24gaWNvbi1pbmxpbmUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0iIzM3YjI0ZCIgdmlld0JveD0iMCAwIDI0IDI0Ij4KICAgICAgICAgICAgICAgICAgICAgPHBhdGggZD0iTTE2LDdWM0gxNFY3SDEwVjNIOFY3SDhDNyw3IDYsOCA2LDlWMTQuNUw5LjUsMThWMjFIMTQuNVYxOEwxOCwxNC41VjlDMTgsOCAxNyw3IDE2LDdaIj48L3BhdGg+CiAgICAgICAgICAgICAgICAgICA8L3N2Zz4KICAgICAgICAgICAgICAgICA8L3N2Zz4KICAgICAgICAgICAgICAgIA=="
         }
       }
     ],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,25 @@
   "activationEvents": [
     "*"
   ],
+  "contributes": {
+    "actions": [
+      {
+        "id": "langserver.status",
+        "actionItem": {
+          "description": "${get(context, `langserver.statusDescription`)}",
+          "iconURL": "${get(context, `langserver.statusIconURL`)}"
+        }
+      }
+    ],
+    "menus": {
+      "editor/title": [
+        {
+          "action": "langserver.status",
+          "when": "resource"
+        }
+      ]
+    }
+  },
   "version": "0.0.0-DEVELOPMENT",
   "license": "MIT",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,23 +22,6 @@ export function activate(): void {
     sourcegraph.languages.registerReferenceProvider(['*'], {
         provideReferences: (doc, pos) => provideLSPResults('textDocument/references', doc, pos),
     })
-
-    sourcegraph.workspace.onDidOpenTextDocument.subscribe(doc => {
-        const icon = (color: string) =>
-            'data:image/svg+xml;base64,' +
-            btoa(
-                `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
-                   <svg class="mdi-icon icon-inline" width="24" height="24" fill="${color}" viewBox="0 0 24 24">
-                     <path d="M16,7V3H14V7H10V3H8V7H8C7,7 6,8 6,9V14.5L9.5,18V21H14.5V18L18,14.5V9C18,8 17,7 16,7Z"></path>
-                   </svg>
-                 </svg>
-                `
-            )
-        sourcegraph.internal.updateContext({ 'langserver.statusIconURL': icon('#37b24d') })
-        sourcegraph.internal.updateContext({
-            'langserver.statusDescription': `Connected to the ${doc.languageId} language server`,
-        })
-    })
 }
 
 async function provideLSPResults(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,23 @@ export function activate(): void {
     sourcegraph.languages.registerReferenceProvider(['*'], {
         provideReferences: (doc, pos) => provideLSPResults('textDocument/references', doc, pos),
     })
+
+    sourcegraph.workspace.onDidOpenTextDocument.subscribe(doc => {
+        const icon = (color: string) =>
+            'data:image/svg+xml;base64,' +
+            btoa(
+                `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24">
+                   <svg class="mdi-icon icon-inline" width="24" height="24" fill="${color}" viewBox="0 0 24 24">
+                     <path d="M16,7V3H14V7H10V3H8V7H8C7,7 6,8 6,9V14.5L9.5,18V21H14.5V18L18,14.5V9C18,8 17,7 16,7Z"></path>
+                   </svg>
+                 </svg>
+                `
+            )
+        sourcegraph.internal.updateContext({ 'langserver.statusIconURL': icon('#37b24d') })
+        sourcegraph.internal.updateContext({
+            'langserver.statusDescription': `Connected to the ${doc.languageId} language server`,
+        })
+    })
 }
 
 async function provideLSPResults(


### PR DESCRIPTION
![2018-10-10 00 18 22](https://user-images.githubusercontent.com/1387653/46719152-059e1280-cc22-11e8-8fb8-b04dc64258b3.gif)

- This will only appear when the corresponding Sourcegraph extension for this language is enabled.
- This does not check the health, and only shows green (not red or yellow)
- There are no links to the /site-admin/code-intelligence page, upstream repo, bugs, etc.

@sqs How do we go about publishing this to Google Storage, and how does this get included in Sourcegraph instances? Do we manually upload the bundle to https://console.cloud.google.com/storage/browser/sourcegraph-cx-dev?project=sourcegraph-dev and overwrite v3.js?

TODO after merging: remove the existing indicator from webapp and browser extension