### PR TITLE
feat: unsubscribe providers when queryLSP throws an error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,26 +2,43 @@ import * as sourcegraph from 'sourcegraph'
 import { toHover } from './backcompat'
 import { sendLSPRequest } from './lsp'
 
+const subscriptions: sourcegraph.Unsubscribable[] = []
+function disable(): void {
+    for (const subscription of subscriptions) {
+        subscription.unsubscribe()
+    }
+}
+
 /** Entrypoint for the language server HTTP adapter Sourcegraph extension. */
 export function activate(): void {
-    sourcegraph.languages.registerHoverProvider(['*'], {
-        provideHover: async (doc, pos) => {
-            const result = await provideLSPResults('textDocument/hover', doc, pos)
-            return toHover(result) // backcompat
-        },
-    })
-    sourcegraph.languages.registerDefinitionProvider(['*'], {
-        provideDefinition: (doc, pos) => provideLSPResults('textDocument/definition', doc, pos),
-    })
-    sourcegraph.languages.registerTypeDefinitionProvider(['*'], {
-        provideTypeDefinition: (doc, pos) => provideLSPResults('textDocument/typeDefinition', doc, pos),
-    })
-    sourcegraph.languages.registerImplementationProvider(['*'], {
-        provideImplementation: (doc, pos) => provideLSPResults('textDocument/implementation', doc, pos),
-    })
-    sourcegraph.languages.registerReferenceProvider(['*'], {
-        provideReferences: (doc, pos) => provideLSPResults('textDocument/references', doc, pos),
-    })
+    subscriptions.push(
+        sourcegraph.languages.registerHoverProvider(['*'], {
+            provideHover: async (doc, pos) => {
+                const result = await provideLSPResults('textDocument/hover', doc, pos)
+                return toHover(result) // backcompat
+            },
+        })
+    )
+    subscriptions.push(
+        sourcegraph.languages.registerDefinitionProvider(['*'], {
+            provideDefinition: (doc, pos) => provideLSPResults('textDocument/definition', doc, pos),
+        })
+    )
+    subscriptions.push(
+        sourcegraph.languages.registerTypeDefinitionProvider(['*'], {
+            provideTypeDefinition: (doc, pos) => provideLSPResults('textDocument/typeDefinition', doc, pos),
+        })
+    )
+    subscriptions.push(
+        sourcegraph.languages.registerImplementationProvider(['*'], {
+            provideImplementation: (doc, pos) => provideLSPResults('textDocument/implementation', doc, pos),
+        })
+    )
+    subscriptions.push(
+        sourcegraph.languages.registerReferenceProvider(['*'], {
+            provideReferences: (doc, pos) => provideLSPResults('textDocument/references', doc, pos),
+        })
+    )
 }
 
 async function provideLSPResults(
@@ -30,11 +47,20 @@ async function provideLSPResults(
     pos: sourcegraph.Position
 ): Promise<any> {
     const root = doc.uri.replace(/#.*$/, '') // remove everything after the '#'
-    const results = await sendLSPRequest({
-        mode: doc.languageId,
-        root,
-        method,
-        params: { textDocument: { uri: doc.uri }, position: { line: pos.line, character: pos.character } },
-    })
-    return results[1].result
+    try {
+        const results = await sendLSPRequest({
+            mode: doc.languageId,
+            root,
+            method,
+            params: { textDocument: { uri: doc.uri }, position: { line: pos.line, character: pos.character } },
+        })
+        return results[1].result
+    } catch (err) {
+        console.error(
+            'An error occurred when sending LSP requests to the language server, disabling this instance of the language extension (reload the page to clear this state). ',
+            err
+        )
+        disable()
+        return undefined
+    }
 }


### PR DESCRIPTION
I'm planning to support running extensions (e.g. Codecov) on private code even when the repository does not exist on the Sourcegraph instance. Doing so will resolve this issue: https://github.com/sourcegraph/browser-extensions/issues/234#issuecomment-430429015

That means that all extensions will run, including language extensions. Unfortunately, when the repository doesn't exist, every hover will 404 and show up in the hover tooltip, which is pretty annoying.

To avoid so many errors popping up in the hover tooltips, this PR suppresses 404s and other network errors so that they do not show up in tooltips but still show up in the console. Errors returned by the language server will still show up in the hover tooltips.