### PR TITLE
Do not stop the extension upon an error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,43 +2,26 @@ import * as sourcegraph from 'sourcegraph'
 import { toHover } from './backcompat'
 import { sendLSPRequest } from './lsp'
 
-const subscriptions: sourcegraph.Unsubscribable[] = []
-function disable(): void {
-    for (const subscription of subscriptions) {
-        subscription.unsubscribe()
-    }
-}
-
 /** Entrypoint for the language server HTTP adapter Sourcegraph extension. */
 export function activate(): void {
-    subscriptions.push(
-        sourcegraph.languages.registerHoverProvider(['*'], {
-            provideHover: async (doc, pos) => {
-                const result = await provideLSPResults('textDocument/hover', doc, pos)
-                return toHover(result) // backcompat
-            },
-        })
-    )
-    subscriptions.push(
-        sourcegraph.languages.registerDefinitionProvider(['*'], {
-            provideDefinition: (doc, pos) => provideLSPResults('textDocument/definition', doc, pos),
-        })
-    )
-    subscriptions.push(
-        sourcegraph.languages.registerTypeDefinitionProvider(['*'], {
-            provideTypeDefinition: (doc, pos) => provideLSPResults('textDocument/typeDefinition', doc, pos),
-        })
-    )
-    subscriptions.push(
-        sourcegraph.languages.registerImplementationProvider(['*'], {
-            provideImplementation: (doc, pos) => provideLSPResults('textDocument/implementation', doc, pos),
-        })
-    )
-    subscriptions.push(
-        sourcegraph.languages.registerReferenceProvider(['*'], {
-            provideReferences: (doc, pos) => provideLSPResults('textDocument/references', doc, pos),
-        })
-    )
+    sourcegraph.languages.registerHoverProvider(['*'], {
+        provideHover: async (doc, pos) => {
+            const result = await provideLSPResults('textDocument/hover', doc, pos)
+            return toHover(result) // backcompat
+        },
+    })
+    sourcegraph.languages.registerDefinitionProvider(['*'], {
+        provideDefinition: (doc, pos) => provideLSPResults('textDocument/definition', doc, pos),
+    })
+    sourcegraph.languages.registerTypeDefinitionProvider(['*'], {
+        provideTypeDefinition: (doc, pos) => provideLSPResults('textDocument/typeDefinition', doc, pos),
+    })
+    sourcegraph.languages.registerImplementationProvider(['*'], {
+        provideImplementation: (doc, pos) => provideLSPResults('textDocument/implementation', doc, pos),
+    })
+    sourcegraph.languages.registerReferenceProvider(['*'], {
+        provideReferences: (doc, pos) => provideLSPResults('textDocument/references', doc, pos),
+    })
 }
 
 async function provideLSPResults(
@@ -56,11 +39,7 @@ async function provideLSPResults(
         })
         return results[1].result
     } catch (err) {
-        console.error(
-            'An error occurred when sending LSP requests to the language server, disabling this instance of the language extension (reload the page to clear this state). ',
-            err
-        )
-        disable()
+        console.error('Code intelligence request', method, 'failed:', err)
         return undefined
     }
 }


### PR DESCRIPTION
#8 both suppressed errors and caused the extension to stop serving code intelligence upon the first error.

This PR makes the extension keep serving code intelligence even when errors occur, and will fix the customer-reported issue https://github.com/sourcegraph/sourcegraph/issues/838

Consequently, on private code, an error will get logged to to the console whenever a hover occurs. This is an acceptable tradeoff until a better solution arises (e.g. checking if the current repo is private and the Sourcegraph URL is set to Sourcegraph.com, or otherwise checking if code intelligence is expected to work at all).