### PR TITLE
feat: parameterize the initializationOptions

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -16,6 +16,9 @@ interface LSPContext {
 
     /** The mode identifier for the language server to communicate with. */
     mode: string
+
+    /** The initializationOptions that are passed in the initialize request. */
+    initializationOptions: any
 }
 
 /** An LSP request. */
@@ -46,7 +49,7 @@ export const sendLSPRequest = memoizeAsync(
                         params: {
                             rootUri: arg.root,
                             mode: arg.mode,
-                            initializationOptions: { mode: arg.mode },
+                            initializationOptions: arg.initializationOptions,
                         },
                     },
                     arg.method ? { id: 1, method: arg.method, params: arg.params } : null,


### PR DESCRIPTION
This allows lang-go to use this extension's code as a dependency and pass through a new `zipURL` field in the `initializationOptions` of the LSP `initialize` request. See how it's used at https://github.com/sourcegraph/lang-go/commit/280de6bce76b62f52d92821cdad44f6e75122933

This PR does not change any behavior of the extension in this repo.